### PR TITLE
Update for modern Linux and add Fedora .spec file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ vxi11_send
 *.o
 *.pyc
 .pc/
+vxi11-*.tar.gz

--- a/CHANGELOG-UD.txt
+++ b/CHANGELOG-UD.txt
@@ -1,0 +1,14 @@
+ 
+Post vxi11 2.0 - 2021-04-13
+---------------------------
+These are the changes made on a clone of the official repository.  An
+appropriate pull request will be made but for the time being the changes
+are documented separately.
+
+* Use tiRPC and link with appropriate libraries.  This is needed for
+  modern Linux systems because the old SunRPC code is only available
+  for compatibility
+* Fix use of install which installs with execute permission by default
+  which is wrong for the header file
+* Fix potentially non-terminated string in _vxi11_client_t list which
+  has a fixed-size buffer for a file name

--- a/CHANGELOG-UD.txt
+++ b/CHANGELOG-UD.txt
@@ -14,3 +14,6 @@ are documented separately.
   has a fixed-size buffer for a file name
 * Handle fgets failure (e.g., on EOF) in vxi11_cmd. Actually return
   the error
+* Simplify argument handling in vxi11_send and in the process fix
+  unnecessary truncation of the command and potential out-of-bounds
+  read

--- a/CHANGELOG-UD.txt
+++ b/CHANGELOG-UD.txt
@@ -17,3 +17,4 @@ are documented separately.
 * Simplify argument handling in vxi11_send and in the process fix
   unnecessary truncation of the command and potential out-of-bounds
   read
+* Install python code as well

--- a/CHANGELOG-UD.txt
+++ b/CHANGELOG-UD.txt
@@ -20,3 +20,4 @@ are documented separately.
 * Install python code as well
 * Add .spec file for Fedora
 * Simplify library directory name handling
+* Automatically determine correct lib directory name

--- a/CHANGELOG-UD.txt
+++ b/CHANGELOG-UD.txt
@@ -19,3 +19,4 @@ are documented separately.
   read
 * Install python code as well
 * Add .spec file for Fedora
+* Simplify library directory name handling

--- a/CHANGELOG-UD.txt
+++ b/CHANGELOG-UD.txt
@@ -12,3 +12,5 @@ are documented separately.
   which is wrong for the header file
 * Fix potentially non-terminated string in _vxi11_client_t list which
   has a fixed-size buffer for a file name
+* Handle fgets failure (e.g., on EOF) in vxi11_cmd. Actually return
+  the error

--- a/CHANGELOG-UD.txt
+++ b/CHANGELOG-UD.txt
@@ -18,3 +18,4 @@ are documented separately.
   unnecessary truncation of the command and potential out-of-bounds
   read
 * Install python code as well
+* Add .spec file for Fedora

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=2.0
+VERSION=2.0ud.1
 
 include config.mk
 
@@ -20,7 +20,7 @@ dist : distclean
 	cp -pr library utils vxi11-$(VERSION)/
 	mkdir vxi11-$(VERSION)/python
 	cp python/setup.py python/vxi11.py vxi11-$(VERSION)/python
-	cp -p config.mk Makefile CMakeLists.txt CHANGELOG.txt README.md GNU_General_Public_License.txt vxi11-$(VERSION)/
+	cp -p config.mk Makefile CMakeLists.txt CHANGELOG.txt README.md GNU_General_Public_License.txt vxi11.spec vxi11-$(VERSION)/
 	tar -zcf vxi11-$(VERSION).tar.gz vxi11-$(VERSION)
 
 distclean :  clean

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,8 @@ install : all
 dist : distclean
 	mkdir vxi11-$(VERSION)
 	cp -pr library utils vxi11-$(VERSION)/
+	mkdir vxi11-$(VERSION)/python
+	cp python/setup.py python/vxi11.py vxi11-$(VERSION)/python
 	cp -p config.mk Makefile CMakeLists.txt CHANGELOG.txt README.md GNU_General_Public_License.txt vxi11-$(VERSION)/
 	tar -zcf vxi11-$(VERSION).tar.gz vxi11-$(VERSION)
 

--- a/config.mk
+++ b/config.mk
@@ -1,4 +1,4 @@
-CFLAGS=-g
+CFLAGS=$(OPTS) $(shell pkg-config --cflags libtirpc)
 LDFLAGS=
 
 INSTALL=install

--- a/library/Makefile
+++ b/library/Makefile
@@ -36,5 +36,5 @@ install: all
 	$(INSTALL) libvxi11.so.${SOVERSION} $(DESTDIR)$(prefix)/lib${LIB_SUFFIX}/
 	ln -sf libvxi11.so.${SOVERSION} $(DESTDIR)$(prefix)/lib${LIB_SUFFIX}/libvxi11.so
 	$(INSTALL) -d $(DESTDIR)$(prefix)/include/
-	$(INSTALL) vxi11_user.h $(DESTDIR)$(prefix)/include/
+	$(INSTALL) -m644 vxi11_user.h $(DESTDIR)$(prefix)/include/
 

--- a/library/Makefile
+++ b/library/Makefile
@@ -8,6 +8,8 @@ ifneq ($(UNAME),SunOS)
 	LDFLAGS:=$(LDFLAGS) -Wl,--version-script=linker.version
 endif
 
+lib = lib
+
 all : libvxi11.so.${SOVERSION}
 
 libvxi11.so.${SOVERSION} : vxi11_user.o vxi11_clnt.o vxi11_xdr.o
@@ -32,9 +34,9 @@ clean:
 	rm -f *.o libvxi11.so.${SOVERSION} vxi11.h vxi11_svc.c vxi11_xdr.c vxi11_clnt.c TAGS
 
 install: all
-	$(INSTALL) -d $(DESTDIR)$(prefix)/lib${LIB_SUFFIX}/
-	$(INSTALL) libvxi11.so.${SOVERSION} $(DESTDIR)$(prefix)/lib${LIB_SUFFIX}/
-	ln -sf libvxi11.so.${SOVERSION} $(DESTDIR)$(prefix)/lib${LIB_SUFFIX}/libvxi11.so
+	$(INSTALL) -d $(DESTDIR)$(prefix)/${lib}/
+	$(INSTALL) libvxi11.so.${SOVERSION} $(DESTDIR)$(prefix)/${lib}/
+	ln -sf libvxi11.so.${SOVERSION} $(DESTDIR)$(prefix)/${lib}/libvxi11.so
 	$(INSTALL) -d $(DESTDIR)$(prefix)/include/
 	$(INSTALL) -m644 vxi11_user.h $(DESTDIR)$(prefix)/include/
 

--- a/library/Makefile
+++ b/library/Makefile
@@ -8,7 +8,7 @@ ifneq ($(UNAME),SunOS)
 	LDFLAGS:=$(LDFLAGS) -Wl,--version-script=linker.version
 endif
 
-lib = lib
+lib = $(shell $(CC) -print-search-dirs|grep '^libraries'|tr ':' '\n'|sed -n 's|.*/\([^/]\+\)/\?$$|\1|p'|grep -m1 'lib\(64\|32\|x32\)')
 
 all : libvxi11.so.${SOVERSION}
 

--- a/library/Makefile
+++ b/library/Makefile
@@ -11,7 +11,7 @@ endif
 all : libvxi11.so.${SOVERSION}
 
 libvxi11.so.${SOVERSION} : vxi11_user.o vxi11_clnt.o vxi11_xdr.o
-	$(CC) $(LDFLAGS) -shared -Wl,-soname,libvxi11.so.${SOVERSION} $^ -o $@
+	$(CC) $(LDFLAGS) -shared -Wl,-soname,libvxi11.so.${SOVERSION} $^ -o $@ $(shell pkg-config --libs libtirpc)
 
 vxi11_user.o: vxi11_user.c vxi11.h
 	$(CC) -fPIC $(CFLAGS) -c $< -o $@

--- a/library/vxi11_user.c
+++ b/library/vxi11_user.c
@@ -65,11 +65,11 @@ struct _VXI11_CLINK {
 
 struct _vxi11_client_t {
 	struct _vxi11_client_t *next;
-	char address[20];
 #ifndef WIN32
 	CLIENT *client_address;
 #endif
 	int link_count;
+	char address[0];
 };
 
 static struct _vxi11_client_t *VXI11_CLIENTS = NULL;
@@ -156,7 +156,7 @@ int vxi11_open_device(VXI11_CLINK **clink, const char *address, char *device)
 		 * is, for this address. Because it's a new client, this
 		 * must be link number 1. Keep track of how many devices we've
 		 * opened so we don't run out of storage space. */
-		client = (struct _vxi11_client_t *)calloc(1, sizeof(struct _vxi11_client_t));
+		client = (struct _vxi11_client_t *)calloc(1, sizeof(struct _vxi11_client_t) + strlen(address) + 1);
 		if (!client) {
 			free(*clink);
 			*clink = NULL;
@@ -183,7 +183,7 @@ int vxi11_open_device(VXI11_CLINK **clink, const char *address, char *device)
 			return 1;
 		}
 
-		strncpy(client->address, address, 20);
+		strcpy(client->address, address);
 		client->client_address = (*clink)->client;
 		client->link_count = 1;
 		client->next = VXI11_CLIENTS;

--- a/utils/vxi11_cmd.c
+++ b/utils/vxi11_cmd.c
@@ -63,7 +63,8 @@ int main(int argc, char *argv[])
 		memset(cmd, 0, 256);	// initialize command string
 		memset(buf, 0, BUF_LEN);	// initialize buffer
 		printf("Input command or query ('q' to exit): ");
-		fgets(cmd, 256, stdin);
+		if (fgets(cmd, 256, stdin) == NULL)
+		  break;
 		cmd[strlen(cmd) - 1] = 0;	// just gets rid of the \n
 		if (strncasecmp(cmd, "q", 1) == 0) {
 			break;
@@ -85,5 +86,5 @@ int main(int argc, char *argv[])
 	}
 
 	ret = vxi11_close_device(clink, device_ip);
-	return 0;
+	return ret;
 }

--- a/utils/vxi11_send.c
+++ b/utils/vxi11_send.c
@@ -35,11 +35,11 @@
 int main(int argc, char *argv[])
 {
 
-	static char *device_ip;
-	char cmd[256];
+	char *device_ip;
+	char *cmd;
 	VXI11_CLINK *clink;
 
-	if (argc < 2) {
+	if (argc < 3) {
 		printf("usage: %s your.inst.ip.addr command\n", argv[0]);
 		exit(1);
 	}
@@ -51,8 +51,7 @@ int main(int argc, char *argv[])
 		exit(2);
 	}
 
-	memset(cmd, 0, 256);	// initialize command string
-	strncpy(cmd, argv[2], 256);
+	cmd = argv[2];
 	vxi11_send(clink, cmd, strlen(cmd));
 	vxi11_close_device(clink, device_ip);
 	return 0;

--- a/vxi11.spec
+++ b/vxi11.spec
@@ -64,7 +64,7 @@ cd ..
 rm -rf ${RPM_BUILD_ROOT}
 mkdir -p ${RPM_BUILD_ROOT}%{_prefix}
 
-%make_install prefix=%{_prefix} LIB_SUFFIX=$(echo %{_lib}|sed 's/lib//')
+%make_install prefix=%{_prefix} lib=%{_lib}
 
 cd python
 %py3_install

--- a/vxi11.spec
+++ b/vxi11.spec
@@ -1,0 +1,108 @@
+Summary: VXI11 Device Communication
+Name: vxi11
+Version: 2.0ud.1
+Release: 1
+URL: https://github.com/drepper/vxi11.git
+Source: vxi11-2.0ud.1.tar.gz
+License: GPLv2+
+
+BuildRequires: gcc
+BuildRequires: make
+BuildRequires: libtirpc-devel
+BuildRequires: rpcgen
+BuildRequires: pkgconf-pkg-config
+BuildRequires: sed
+
+%define abi 1
+
+%description
+This library allows communication using the VXI11 RPC protocol with
+Ethernet-enabled devices such as oscilloscopes, logic analyzers, 
+function generators, power supplies, etc.  The specific commands vary
+by device.
+
+%package utils
+Summary: Utilities to use VXI11 library to control devices
+License: GPLv2+
+Requires: vxi11 = %{version}-%{release}
+
+%description utils
+This package contains the utilities which use the VXI11 library to
+control devices.  The vxi11_cmd utility provides a simple interactive
+shell to send commands and queries to one device at a time.  The
+vxi11_send utility allows to send a single command to a device.
+
+%package devel
+Summary: Files needed for using the VXI11 library
+License: GPLv2+
+Requires: vxi11 = %{version}-%{release}
+
+%description devel
+The vxi11-devel package contains the files needed to write code that
+uses the libvxi11 library.
+
+%package -n python3-vxi11
+Summary: Python interface to VXI11 library
+License: GPLv2+
+Requires: vxi11 = %{version}-%{release}
+
+%description -n python3-vxi11
+This package contains a Python binding of the libvxi11 library to
+control Ethernet-enabled devices.
+
+%prep
+%setup -q
+
+%build
+make OPTS="${RPM_OPT_FLAGS} -Wno-unused-variable" CC=gcc
+
+cd python
+%py3_build
+cd ..
+
+%install
+rm -rf ${RPM_BUILD_ROOT}
+mkdir -p ${RPM_BUILD_ROOT}%{_prefix}
+
+%make_install prefix=%{_prefix} LIB_SUFFIX=$(echo %{_lib}|sed 's/lib//')
+
+cd python
+%py3_install
+cd ..
+
+%clean
+rm -fr ${RPM_BUILD_ROOT}
+
+%post -p /sbin/ldconfig
+
+%postun -p /sbin/ldconfig
+
+%files
+%defattr(-,root,root)
+%license GNU_General_Public_License.txt
+%doc README.md CHANGELOG.txt
+%{_libdir}/libvxi11.so.%{abi}
+
+%files utils
+%defattr(-,root,root)
+%{_bindir}/vxi11_cmd
+%{_bindir}/vxi11_send
+
+%files devel
+%defattr(-,root,root)
+%{_libdir}/libvxi11.so
+%{_includedir}/vxi11_user.h
+
+%files -n python3-vxi11
+%defattr(-,root,root)
+%{python3_sitelib}/vxi11.py
+%{python3_sitelib}/vxi11-*.egg-info
+%{python3_sitelib}/__pycache__/*
+
+%changelog
+* Tue Apr 13 2021 Ulrich Drepper <drepper@gmail.com> 2.0ud.1-1
+- Build based on cloned git repository which contains the patches
+* Mon Apr 12 2021 Ulrich Drepper <drepper@gmail.com> 2.0-1
+- Create Fedora .spec file for the unchanged git repository
+- fix a few bugs including potential buffer overruns
+- add patch to distribute python code


### PR DESCRIPTION
Hello Steve,

I have no idea whether you're still interested in this.  If not, let me know and I'll just carry on in my cloned repository.

I've been using a hacky build of your vxi11 for a while and only in the last days finally took the steps to update the code for a modern system and create the configuration to create RPM packages.  The result works on my Fedora 33 system.

In the process I've fixed potential out-of-bound reads and string truncations.